### PR TITLE
Library / language upgrades. Fixed issue with RaftClusterActor

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,0 +1,1 @@
+crossScalaVersions := Seq("2.11.4", "2.10.4")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,7 +8,6 @@ object ApplicationBuild extends Build {
 
   val appName = "akka-raft"
   val appVersion = "1.0-SNAPSHOT"
-  val appScalaVersion = "2.10.4"
 
   import Dependencies._
 
@@ -18,8 +17,7 @@ object ApplicationBuild extends Build {
     .configs(MultiJvm)
     .settings(multiJvmSettings: _*)
     .settings(
-      libraryDependencies ++= generalDependencies,
-      scalaVersion := appScalaVersion
+      libraryDependencies ++= generalDependencies
     )
 
   lazy val multiJvmSettings = SbtMultiJvm.multiJvmSettings ++ Seq(
@@ -38,7 +36,7 @@ object ApplicationBuild extends Build {
 }
 
 object Dependencies {
-    val akkaVersion = "2.3.6"
+    val akkaVersion = "2.3.8"
     val generalDependencies = Seq(
       "com.typesafe.akka" %% "akka-actor"     % akkaVersion,
       "com.typesafe.akka" %% "akka-slf4j"     % akkaVersion,
@@ -50,6 +48,6 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % "test",
 
       "org.mockito"        % "mockito-core"   % "1.9.5"     % "test",
-      "org.scalatest"     %% "scalatest"      % "2.0"       % "test"
+      "org.scalatest"     %% "scalatest"      % "2.2.1"     % "test"
     )
   }

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,1 +1,0 @@
-scalaVersion := "2.10.4"


### PR DESCRIPTION
+ Upgraded to Akka 2.3.8
+ Added cross compiling to Scala 2.11.4
+ Fixed an issue with the RaftClusterActor that caused the Leader to spam itself with AppendEntries messages after an election. I created a simple example to demonstrate how I was using RaftClusterActor and you can see the issue in action on the "broken" branch of [bradegler/akka-raft-example](https://github.com/bradegler/akka-raft-example/tree/broken)