### PR TITLE
Correct handling of term updates during the election for Candidate/Follower

### DIFF
--- a/src/main/scala/pl/project13/scala/akka/raft/Candidate.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/Candidate.scala
@@ -21,7 +21,7 @@ private[raft] trait Candidate {
     case Event(BeginElection, m: ElectionMeta) =>
       if (m.config.members.isEmpty) {
         log.warning("Tried to initialize election with no members...")
-        goto(Follower) using m.forFollower
+        goto(Follower) using m.forFollower()
       } else {
         log.info("Initializing election (among {} nodes) for {}", m.config.members.size, m.currentTerm)
 
@@ -32,28 +32,55 @@ private[raft] trait Candidate {
         stay() using includingThisVote.withVoteFor(m.currentTerm, m.clusterSelf)
       }
 
-    case Event(msg: RequestVote, m: ElectionMeta) if m.canVoteIn(msg.term) =>
-      sender ! VoteCandidate(m.currentTerm)
-      stay() using m.withVoteFor(msg.term, candidate())
+		case Event(msg: RequestVote, m: ElectionMeta) if msg.term < m.currentTerm =>
+			log.info("Rejecting RequestVote msg by {} in {}. Received stale {}.", candidate, m.currentTerm, msg.term)
+			candidate ! DeclineCandidate(m.currentTerm)
+			stay()
+
+		case Event(msg: RequestVote, m: ElectionMeta) if msg.term > m.currentTerm =>
+			log.info("Received newer {}. Current term is {}. Revert to follower state.", msg.term, m.currentTerm)
+			goto(Follower) using m.forFollower(msg.term)
 
     case Event(msg: RequestVote, m: ElectionMeta) =>
-      sender ! DeclineCandidate(msg.term)
-      stay()
+			if (m.canVoteIn(msg.term)) {
+				log.info("Voting for {} in {}.", candidate, m.currentTerm)
+				candidate ! VoteCandidate(m.currentTerm)
+				stay() using m.withVoteFor(m.currentTerm, candidate)
+			} else {
+				log.info("Rejecting RequestVote msg by {} in {}. Already voted for {}", candidate, m.currentTerm, m.votes.get(msg.term))
+				sender ! DeclineCandidate(m.currentTerm)
+				stay()
+			}
+
+		case Event(VoteCandidate(term), m: ElectionMeta) if term < m.currentTerm =>
+			log.info("Rejecting VoteCandidate msg by {} in {}. Received stale {}.", voter(), m.currentTerm, term)
+			voter ! DeclineCandidate(m.currentTerm)
+			stay()
+
+		case Event(VoteCandidate(term), m: ElectionMeta) if term > m.currentTerm =>
+			log.info("Received newer {}. Current term is {}. Revert to follower state.", term, m.currentTerm)
+			goto(Follower) using m.forFollower(term)
 
     case Event(VoteCandidate(term), m: ElectionMeta) =>
       val includingThisVote = m.incVote
 
       if (includingThisVote.hasMajority) {
-        log.info("Received vote by {}; Won election with {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
+        log.info("Received vote by {}. Won election with {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
         goto(Leader) using m.forLeader
       } else {
-        log.info("Received vote by {}; Have {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
+        log.info("Received vote by {}. Have {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
         stay() using includingThisVote
       }
 
     case Event(DeclineCandidate(term), m: ElectionMeta) =>
-      log.info("Rejected vote by {}, in term {}", voter(), term)
-      stay()
+			if (term > m.currentTerm) {
+				log.info("Received newer {}. Current term is {}. Revert to follower state.", term, m.currentTerm)
+				goto(Follower) using m.forFollower(term)
+			} else {
+				log.info("Candidate is declined by {} in term {}", sender(), m.currentTerm)
+				stay()
+			}
+
 
     // end of election
 
@@ -64,7 +91,7 @@ private[raft] trait Candidate {
       if (leaderIsAhead) {
         log.info("Reverting to Follower, because got AppendEntries from Leader in {}, but am in {}", append.term, m.currentTerm)
         m.clusterSelf forward append
-        goto(Follower) using m.forFollower
+        goto(Follower) using m.forFollower()
       } else {
         stay()
       }
@@ -78,7 +105,7 @@ private[raft] trait Candidate {
     // would like to start election, but I'm all alone! ;-(
     case Event(ElectionTimeout, m: ElectionMeta) =>
       log.info("Voting timeout, unable to start election, don't know enough nodes (members: {})...", m.config.members.size)
-      goto(Follower) using m.forFollower
+      goto(Follower) using m.forFollower()
 
     case Event(AskForState, _) =>
       sender() ! IAmInState(Candidate)

--- a/src/main/scala/pl/project13/scala/akka/raft/protocol/StateMetadata.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/protocol/StateMetadata.scala
@@ -79,9 +79,9 @@ private[protocol] trait StateMetadata extends Serializable {
 
     def withVoteFor(term: Term, candidate: ActorRef) = copy(votes = votes + (term -> candidate))
 
-    def forLeader: LeaderMeta        = LeaderMeta(clusterSelf, currentTerm, config)
-    def forFollower: Meta            = Meta(clusterSelf, currentTerm, config, Map.empty)
-    def forNewElection: ElectionMeta = this.forFollower.forNewElection
+    def forLeader: LeaderMeta = LeaderMeta(clusterSelf, currentTerm, config)
+    def forFollower(term: Term = currentTerm): Meta = Meta(clusterSelf, term, config, Map.empty)
+    def forNewElection: ElectionMeta = this.forFollower().forNewElection
   }
 
   case class LeaderMeta(

--- a/src/test/scala/pl/project13/scala/akka/raft/FollowerTest.scala
+++ b/src/test/scala/pl/project13/scala/akka/raft/FollowerTest.scala
@@ -64,6 +64,15 @@ class FollowerTest extends RaftSpec with BeforeAndAfterEach
     expectMsg(DeclineCandidate(Term(2)))
   }
 
+	it should "update term number after getting a request with higher term number" in {
+		follower.setState(Follower, data)
+
+		follower ! RequestVote(Term(3), self, Term(3), 3)
+		expectMsg(VoteCandidate(Term(3)))
+
+		follower.stateData.currentTerm shouldBe Term(3)
+	}
+
   it should "become a Candidate if the electionTimeout has elapsed" in {
     // given
     follower.setState(Follower, data)


### PR DESCRIPTION
According to the raft paper 
"Current terms are exchanged whenever servers communicate; if one server’s current term is smaller than the other’s, then it updates its current term to the larger value. If a candidate or leader discovers that its term is out of date, it immediately reverts to follower state. If a server receives a request with a stale term number, it rejects the request."

This pull request implements this rules for election phase of Follower/Candidate states. It also fixes the #46 and #47 issues.