### PR TITLE
Stores non-volatile state with akka-persistence

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -36,7 +36,7 @@ object ApplicationBuild extends Build {
 }
 
 object Dependencies {
-    val akkaVersion = "2.4.0"
+    val akkaVersion = "2.4.4"
     val generalDependencies = Seq(
       "com.typesafe.akka" %% "akka-actor"     % akkaVersion,
       "com.typesafe.akka" %% "akka-slf4j"     % akkaVersion,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -47,6 +47,9 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-testkit"            % akkaVersion % "test",
       "com.typesafe.akka" %% "akka-multi-node-testkit" % akkaVersion % "test",
 
+      "org.iq80.leveldb" % "leveldb" % "0.7",
+      "org.fusesource.leveldbjni" % "leveldbjni-all" % "1.8",
+
       "org.mockito"        % "mockito-core"   % "1.9.5"     % "test",
       "org.scalatest"     %% "scalatest"      % "2.2.1"     % "test"
     )

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -4,6 +4,11 @@ akka {
   # This is useful when for example you have a large cluster, but only want to run raft on a selected subset of the nodes.
   # akka.cluster.roles = [ "raft" ]
 
+  persistence.journal.plugin = "akka.persistence.journal.leveldb"
+  persistence.snapshot-store.plugin = "akka.persistence.snapshot-store.local"
+  persistence.journal.leveldb.dir = "target/journal"
+  persistence.snapshot-store.local.dir = "target/snapshots"
+
   extensions = [
     "pl.project13.scala.akka.raft.compaction.LogCompactionExtension"
   ]

--- a/src/main/scala/pl/project13/scala/akka/raft/Candidate.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/Candidate.scala
@@ -21,15 +21,14 @@ private[raft] trait Candidate {
     case Event(BeginElection, m: Meta) =>
       if (m.config.members.isEmpty) {
         log.warning("Tried to initialize election with no members...")
-        goto(Follower) using m.forFollower()
+        goto(Follower) applying GoToFollowerEvent()
       } else {
         log.info("Initializing election (among {} nodes) for {}", m.config.members.size, m.currentTerm)
 
         val request = RequestVote(m.currentTerm, m.clusterSelf, replicatedLog.lastTerm, replicatedLog.lastIndex)
         m.membersExceptSelf foreach { _ ! request }
 
-        val includingThisVote = m.incVote
-        stay() using includingThisVote.withVoteFor(m.clusterSelf)
+        stay() applying VoteForSelfEvent()
       }
 
     case Event(msg: RequestVote, m: Meta) if msg.term < m.currentTerm =>
@@ -39,13 +38,13 @@ private[raft] trait Candidate {
 
     case Event(msg: RequestVote, m: Meta) if msg.term > m.currentTerm =>
       log.info("Received newer {}. Current term is {}. Revert to follower state.", msg.term, m.currentTerm)
-      goto(Follower) using m.forFollower(msg.term)
+      goto(Follower) applying GoToFollowerEvent(Some(msg.term))
 
     case Event(msg: RequestVote, m: Meta) =>
       if (m.canVoteIn(msg.term)) {
         log.info("Voting for {} in {}.", candidate, m.currentTerm)
         candidate ! VoteCandidate(m.currentTerm)
-        stay() using m.withVoteFor(candidate)
+        stay() applying VoteForEvent(candidate)
       } else {
         log.info("Rejecting RequestVote msg by {} in {}. Already voted for {}", candidate, m.currentTerm, m.votedFor.get)
         sender ! DeclineCandidate(m.currentTerm)
@@ -59,23 +58,24 @@ private[raft] trait Candidate {
 
     case Event(VoteCandidate(term), m: Meta) if term > m.currentTerm =>
       log.info("Received newer {}. Current term is {}. Revert to follower state.", term, m.currentTerm)
-      goto(Follower) using m.forFollower(term)
+      goto(Follower) applying GoToFollowerEvent(Some(term))
 
     case Event(VoteCandidate(term), m: Meta) =>
-      val includingThisVote = m.incVote
+      val votesReceived = m.votesReceived + 1
 
-      if (includingThisVote.hasMajority) {
-        log.info("Received vote by {}. Won election with {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
-        goto(Leader) using m.forLeader
+      val hasWonElection = votesReceived > m.config.members.size / 2
+      if (hasWonElection) {
+        log.info("Received vote by {}. Won election with {} of {} votes", voter(), votesReceived, m.config.members.size)
+        goto(Leader) applying GoToLeaderEvent()
       } else {
-        log.info("Received vote by {}. Have {} of {} votes", voter(), includingThisVote.votesReceived, m.config.members.size)
-        stay() using includingThisVote
+        log.info("Received vote by {}. Have {} of {} votes", voter(), votesReceived, m.config.members.size)
+        stay applying IncrementVoteEvent()
       }
 
     case Event(DeclineCandidate(term), m: Meta) =>
       if (term > m.currentTerm) {
         log.info("Received newer {}. Current term is {}. Revert to follower state.", term, m.currentTerm)
-        goto(Follower) using m.forFollower(term)
+        goto(Follower) applying GoToFollowerEvent(Some(term))
       } else {
         log.info("Candidate is declined by {} in term {}", sender(), m.currentTerm)
         stay()
@@ -91,7 +91,7 @@ private[raft] trait Candidate {
       if (leaderIsAhead) {
         log.info("Reverting to Follower, because got AppendEntries from Leader in {}, but am in {}", append.term, m.currentTerm)
         m.clusterSelf forward append
-        goto(Follower) using m.forFollower()
+        goto(Follower) applying GoToFollowerEvent()
       } else {
         stay()
       }
@@ -100,12 +100,12 @@ private[raft] trait Candidate {
     case Event(ElectionTimeout, m: Meta) if m.config.members.size > 1 =>
       log.info("Voting timeout, starting a new election (among {})...", m.config.members.size)
       m.clusterSelf ! BeginElection
-      stay() using m.forNewElection
+      stay() applying StartElectionEvent()
 
     // would like to start election, but I'm all alone! ;-(
     case Event(ElectionTimeout, m: Meta) =>
       log.info("Voting timeout, unable to start election, don't know enough nodes (members: {})...", m.config.members.size)
-      goto(Follower) using m.forFollower()
+      goto(Follower) applying GoToFollowerEvent()
 
     case Event(AskForState, _) =>
       sender() ! IAmInState(Candidate)

--- a/src/main/scala/pl/project13/scala/akka/raft/Leader.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/Leader.scala
@@ -43,9 +43,9 @@ private[raft] trait Leader {
       replicateLog(meta)
 
       if (meta.config.isPartOfNewConfiguration(m.clusterSelf))
-        stay() using meta
+        stay() applying KeepStateEvent()
       else
-        goto(Follower) using meta.forFollower() // or maybe goto something else?
+        goto(Follower) applying GoToFollowerEvent()
 
     // rogue Leader handling
     case Event(append: AppendEntries[Command], m: Meta) if append.term > m.currentTerm =>

--- a/src/main/scala/pl/project13/scala/akka/raft/RaftActor.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/RaftActor.scala
@@ -1,6 +1,6 @@
 package pl.project13.scala.akka.raft
 
-import akka.actor.{Actor, ActorRef, LoggingFSM}
+import akka.actor.{Actor, LoggingFSM}
 import scala.concurrent.duration._
 
 import model._
@@ -126,8 +126,8 @@ abstract class RaftActor extends Actor with LoggingFSM[RaftState, Metadata]
   }
 
   /** Stop being the Leader */
-  def stepDown(m: LeaderMeta) = {
-    goto(Follower) using m.forFollower
+  def stepDown(m: Meta) = {
+    goto(Follower) using m.forFollower()
   }
 
   /** Stay in current state and reset the election timeout */

--- a/src/main/scala/pl/project13/scala/akka/raft/RaftActor.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/RaftActor.scala
@@ -1,15 +1,17 @@
 package pl.project13.scala.akka.raft
 
-import akka.actor.{Actor, LoggingFSM}
-import scala.concurrent.duration._
-
-import model._
-import protocol._
-import scala.concurrent.forkjoin.ThreadLocalRandom
+import akka.actor.Actor
+import akka.persistence.fsm.PersistentFSM
 import pl.project13.scala.akka.raft.compaction.LogCompactionExtension
 import pl.project13.scala.akka.raft.config.RaftConfiguration
+import pl.project13.scala.akka.raft.model._
+import pl.project13.scala.akka.raft.protocol._
 
-abstract class RaftActor extends Actor with LoggingFSM[RaftState, Metadata]
+import scala.concurrent.duration._
+import scala.concurrent.forkjoin.ThreadLocalRandom
+import scala.reflect._
+
+abstract class RaftActor extends Actor with PersistentFSM[RaftState, Meta, DomainEvent]
   with ReplicatedStateMachine
   with Follower with Candidate with Leader with SharedBehaviors {
 
@@ -42,6 +44,23 @@ abstract class RaftActor extends Actor with LoggingFSM[RaftState, Metadata]
   // end of raft member state --------------
 
   val heartbeatInterval: FiniteDuration = raftConfig.heartbeatInterval
+
+
+  override implicit def domainEventClassTag: ClassTag[DomainEvent] = classTag[DomainEvent]
+
+  override def persistenceId = "RaftActor-" + self.path.name
+
+  override def applyEvent(domainEvent: DomainEvent, data: Meta): Meta = domainEvent match  {
+    case GoToFollowerEvent(term) => term.fold(data.forFollower())(t => data.forFollower(t))
+    case GoToLeaderEvent() => data.forLeader
+    case StartElectionEvent() => data.forNewElection
+    case KeepStateEvent() => data
+    case VoteForEvent(candidate) => data.withVoteFor(candidate)
+    case IncrementVoteEvent() => data.incVote
+    case VoteForSelfEvent() => data.incVote.withVoteFor(data.clusterSelf)
+    case WithNewConfigEvent(term, config) => term.fold(data.withConfig(config))(t => data.withConfig(config).withTerm(t))
+    case WithNewClusterSelf(s) => data.copy(clusterSelf = s)
+  }
 
   def nextElectionDeadline(): Deadline = randomElectionTimeout(
     from = raftConfig.electionTimeoutMin,
@@ -119,15 +138,15 @@ abstract class RaftActor extends Actor with LoggingFSM[RaftState, Metadata]
 
     if (m.config.members.isEmpty) {
       // cluster is still discovering nodes, keep waiting
-      goto(Follower) using m
+      goto(Follower) applying KeepStateEvent()
     } else {
-      goto(Candidate) using m.forNewElection forMax nextElectionDeadline().timeLeft
+      goto(Candidate) applying StartElectionEvent() forMax nextElectionDeadline().timeLeft
     }
   }
 
   /** Stop being the Leader */
   def stepDown(m: Meta) = {
-    goto(Follower) using m.forFollower()
+    goto(Follower) applying GoToFollowerEvent()
   }
 
   /** Stay in current state and reset the election timeout */

--- a/src/main/scala/pl/project13/scala/akka/raft/protocol/DomainEvent.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/protocol/DomainEvent.scala
@@ -1,0 +1,21 @@
+package pl.project13.scala.akka.raft.protocol
+
+import akka.actor.ActorRef
+import pl.project13.scala.akka.raft.ClusterConfiguration
+import pl.project13.scala.akka.raft.model.Term
+
+/**
+ * Events used to persist changes to FSM internal state
+ */
+sealed trait DomainEvent
+case class UpdateTermEvent(t: Term) extends DomainEvent
+case class VoteForEvent(voteFor: ActorRef) extends DomainEvent
+case class VoteForSelfEvent() extends DomainEvent
+case class IncrementVoteEvent() extends DomainEvent
+case class GoToFollowerEvent(t: Option[Term] = None) extends DomainEvent
+case class WithNewClusterSelf(self: ActorRef) extends DomainEvent
+case class WithNewConfigEvent(t: Option[Term] = None, config: ClusterConfiguration) extends DomainEvent
+case class GoToLeaderEvent() extends DomainEvent
+case class StartElectionEvent() extends DomainEvent
+case class KeepStateEvent() extends DomainEvent
+

--- a/src/main/scala/pl/project13/scala/akka/raft/protocol/RaftStates.scala
+++ b/src/main/scala/pl/project13/scala/akka/raft/protocol/RaftStates.scala
@@ -1,5 +1,7 @@
 package pl.project13.scala.akka.raft.protocol
 
+import akka.persistence.fsm.PersistentFSM.FSMState
+
 /**
  * States used by the Raft FSM.
  *
@@ -8,17 +10,25 @@ package pl.project13.scala.akka.raft.protocol
  */
 trait RaftStates {
 
-  sealed trait RaftState
+  sealed trait RaftState extends FSMState
 
   /** In this phase the member awaits to get it's [[pl.project13.scala.akka.raft.ClusterConfiguration]] */
-  case object Init      extends RaftState
+  case object Init extends RaftState {
+    override def identifier: String = "Init"
+  }
 
   /** A Follower can take writes from a Leader; If doesn't get any heartbeat, may decide to become a Candidate */
-  case object Follower  extends RaftState
+  case object Follower extends RaftState {
+    override def identifier: String = "Follower"
+  }
 
   /** A Candidate tries to become a Leader, by issuing [[pl.project13.scala.akka.raft.protocol.RaftProtocol.RequestVote]] */
-  case object Candidate extends RaftState
+  case object Candidate extends RaftState {
+    override def identifier: String = "Candidate"
+  }
 
-  /** The Leader is responsible for taking writes, and commiting entries, as well as keeping the heartbeat to all members */
-  case object Leader    extends RaftState
+  /** The Leader is responsible for taking writes, and committing entries, as well as keeping the heartbeat to all members */
+  case object Leader extends RaftState {
+    override def identifier: String = "Leader"
+  }
 }

--- a/src/test/scala/pl/project13/scala/akka/raft/CandidateTest.scala
+++ b/src/test/scala/pl/project13/scala/akka/raft/CandidateTest.scala
@@ -6,7 +6,6 @@ import org.scalatest.BeforeAndAfterEach
 import org.scalatest.concurrent.Eventually
 import scala.concurrent.duration._
 import org.scalatest.time.{Millis, Span}
-import pl.project13.scala.akka.raft.example.WordConcatRaftActor
 import pl.project13.scala.akka.raft.model.{Entry, Term}
 import pl.project13.scala.akka.raft.example.protocol._
 
@@ -18,7 +17,7 @@ class CandidateTest extends RaftSpec with BeforeAndAfterEach
 
   val candidate = TestFSMRef(new SnapshottingWordConcatRaftActor with EventStreamAllMessages)
 
-  var data: ElectionMeta = _
+  var data: Meta = _
   
   val initialMembers = 0
 

--- a/src/test/scala/pl/project13/scala/akka/raft/LeaderElectionTest.scala
+++ b/src/test/scala/pl/project13/scala/akka/raft/LeaderElectionTest.scala
@@ -1,9 +1,7 @@
 package pl.project13.scala.akka.raft
 
-import pl.project13.scala.akka.raft.protocol._
 import org.scalatest.concurrent.Eventually
-import scala.concurrent.duration._
-import org.scalatest.time.{Seconds, Millis, Span}
+import org.scalatest.time.{Millis, Seconds, Span}
 
 class LeaderElectionTest extends RaftSpec(callingThreadDispatcher = false)
   with Eventually {

--- a/src/test/scala/pl/project13/scala/akka/raft/LeaderTest.scala
+++ b/src/test/scala/pl/project13/scala/akka/raft/LeaderTest.scala
@@ -15,7 +15,7 @@ class LeaderTest extends TestKit(ActorSystem("test-system")) with FlatSpecLike w
 
   val leader = TestFSMRef(new SnapshottingWordConcatRaftActor)
 
-  var data: LeaderMeta = _
+  var data: Meta = _
   
   before {
     data = Meta.initial(leader)


### PR DESCRIPTION
Fixes #62 

Hi! 

I decided to make a PR with my change as "is" because fixing the tests is a really huge task that I think should be addressed separately. I actually tried to fix the tests by changing all references from TestFsmRef/TestActorRef to normal raft actors but I stuck on rewriting "unit" tests for Follower/Leader/Candidate. When I mixin EventStreamAllMessages into actor I get 
_Unhandled message ... in state Init_ and it looks like actor stuck after that until my assertion is fired due to timeout. I don't see any log messages after. Also I'm not quite sure that its possible to keep the tests mentioned above as they are cause they are testing some responses to messages in a concrete state and its hardly possible to make this assertions reliable when you have the whole cluster on nodes where state is constantly changing. Anyway, I will continue to work on this and try to figure it out :)